### PR TITLE
Add default packages to attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,5 +7,5 @@ default['htpasswd']['path']        = ::File.join(node['htpasswd']['install_dir']
 
 default['htpasswd']['packages'] = value_for_platform_family(
   ['rhel', 'fedora', 'suse'] => ['httpd-tools'],
-  'debian' => ['apache2-utils']
+  ['default', 'debian'] => ['apache2-utils']
 )


### PR DESCRIPTION
packages was missing a default attribute, this resulted in the following error when running chefspec testing locally on ubuntu:

```
NoMethodError:
       undefined method `each' for nil:NilClass
     # /tmp/d20151013-20375-1tqy8ps/cookbooks/htpasswd/recipes/packages.rb:1:in `from_file'
     # /tmp/d20151013-20375-1tqy8ps/cookbooks/htpasswd/recipes/default.rb:21:in `from_file'
```
